### PR TITLE
enable pdf

### DIFF
--- a/.openpublishing.publish.config.json
+++ b/.openpublishing.publish.config.json
@@ -63,6 +63,5 @@
     "Pdf": {
       "template_folder": "_themes.pdf"
     }
-  },
-  "need_generate_pdf": false
+  }
 }


### PR DESCRIPTION
# Praegu avalikke panuseid vastu ei võeta

Hoidla on tehtud avalikuks selleks, et hõlbustada selle sisu allalaadimist ja kasutamist kohandatud abiinfolahenduste loomisel.
Praegu me sellele hoidlale ega sisule avalikke panuseid vastu ei võta.
Kui soovite panustada Microsofti avalikku sisusse, avage hoidla ingliskeelne versioon, kus töödeldakse avalikke panuseid.
